### PR TITLE
Support PREFAB_API_URL_OVERRIDE

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x', '1.22.x']
+        go-version: [ '1.22.x', '1.23.x']
 
     steps:
     - uses: actions/checkout@v4

--- a/pkg/internal/anyhelpers/helpers.go
+++ b/pkg/internal/anyhelpers/helpers.go
@@ -1,6 +1,8 @@
 package anyhelpers
 
-import "reflect"
+import (
+	"reflect"
+)
 
 // DetectAndReturnStringListIfPresent checks if the input interface{} is a slice with only string elements
 // and returns the slice and a bool indicating if a string slice was found.

--- a/pkg/internal/options/config_sources_test.go
+++ b/pkg/internal/options/config_sources_test.go
@@ -1,0 +1,22 @@
+package options_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prefab-cloud/prefab-cloud-go/pkg/internal/options"
+)
+
+func TestGetDefaultConfigSources(t *testing.T) {
+	sources := options.GetDefaultConfigSources()
+
+	require.Len(t, sources, 1)
+
+	assert.Equal(t, options.ConfigSource{
+		Store:   options.APIStore,
+		Raw:     "api:prefab",
+		Default: true,
+	}, sources[0])
+}

--- a/pkg/internal/options/options.go
+++ b/pkg/internal/options/options.go
@@ -43,9 +43,15 @@ type Options struct {
 const timeoutDefault = 10.0
 
 func GetDefaultOptions() Options {
+	var apiURLs []string
+
+	if os.Getenv("PREFAB_API_URL_OVERRIDE") != "" {
+		apiURLs = []string{os.Getenv("PREFAB_API_URL_OVERRIDE")}
+	}
+
 	return Options{
 		APIKey:                       "",
-		APIURLs:                      nil,
+		APIURLs:                      apiURLs,
 		InitializationTimeoutSeconds: timeoutDefault,
 		OnInitializationFailure:      ReturnError,
 		GlobalContext:                contexts.NewContextSet(),
@@ -84,9 +90,13 @@ func (o *Options) PrefabAPIURLEnvVarOrSetting() ([]string, error) {
 		return apiURLs, nil
 	}
 
-	for _, url := range o.APIURLs {
-		if url != "" {
-			apiURLs = append(apiURLs, url)
+	if os.Getenv("PREFAB_API_URL_OVERRIDE") != "" {
+		apiURLs = []string{os.Getenv("PREFAB_API_URL_OVERRIDE")}
+	} else {
+		for _, url := range o.APIURLs {
+			if url != "" {
+				apiURLs = append(apiURLs, url)
+			}
 		}
 	}
 

--- a/pkg/internal/options/options_test.go
+++ b/pkg/internal/options/options_test.go
@@ -1,0 +1,37 @@
+package options_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/prefab-cloud/prefab-cloud-go/pkg/internal/options"
+)
+
+func TestGetDefaultOptions(t *testing.T) {
+	// When ENV var PREFAB_API_URL_OVERRIDE is not set we use the default API URL.
+	t.Setenv("PREFAB_API_URL_OVERRIDE", "")
+
+	o := options.GetDefaultOptions()
+
+	assert.Empty(t, o.APIKey)
+	assert.Nil(t, o.APIURLs)
+	assert.Equal(t, 10.0, o.InitializationTimeoutSeconds)
+	assert.Equal(t, options.ReturnError, o.OnInitializationFailure)
+	assert.NotNil(t, o.GlobalContext)
+	assert.Len(t, o.Sources, 1)
+	assert.Equal(t, options.ConfigSource{
+		Store:   options.APIStore,
+		Raw:     "api:prefab",
+		Default: true,
+	}, o.Sources[0])
+
+	// When ENV var PREFAB_API_URL_OVERRIDE is set, that should be used instead
+	// of the default API URL.
+	desiredAPIURL := "https://api.staging-prefab.cloud"
+
+	t.Setenv("PREFAB_API_URL_OVERRIDE", desiredAPIURL)
+
+	o = options.GetDefaultOptions()
+	assert.Equal(t, []string{desiredAPIURL}, o.APIURLs)
+}


### PR DESCRIPTION
This is an escape-hatch in the event of an emergency. It can override
default and `WithAPIURLs`-provided URLs.
