### PR TITLE
Fix a bug in client.GetConfigMatch

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -476,7 +476,8 @@ func (c *ContextBoundClient) GetConfig(key string) (*prefabProto.Config, bool) {
 
 // GetConfigMatch returns a ConfigMatch object for a given key and context. You're unlikely to need this method.
 func (c *ContextBoundClient) GetConfigMatch(key string, contextSet ContextSet) (*ConfigMatch, error) {
-	getResult, err := c.client.internalGetValue(key, contextSet)
+	mergedContextSet := *contexts.Merge(c.context, &contextSet)
+	getResult, err := c.client.internalGetValue(key, mergedContextSet)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testdata/download.json
+++ b/pkg/testdata/download.json
@@ -46,6 +46,49 @@
       "rows": [{ "values": [{ "value": { "string": "hello world" } }] }],
       "configType": "CONFIG",
       "valueType": "STRING"
+    },
+    {
+      "id": "17381662797792732",
+      "projectId": "202",
+      "key": "test.with.rule",
+      "changedBy": { "email": "jeffrey.chupp@prefab.cloud" },
+      "rows": [
+        {
+          "values": [
+            {
+              "value": {
+                "string": "default"
+              }
+            }
+          ]
+        },
+        {
+          "projectEnvId": "308",
+          "values": [
+            {
+              "criteria": [
+                {
+                  "propertyName": "prefab-api-key.user-id",
+                  "operator": "PROP_IS_ONE_OF",
+                  "valueToMatch": {
+                    "stringList": {
+                      "values": [
+                        "1039"
+                      ]
+                    }
+                  }
+                }
+              ],
+              "value": {
+                "string": "targeted"
+              }
+            }
+          ]
+        }
+      ],
+      "configType": "CONFIG",
+      "valueType": "STRING",
+      "sendToClientSdk": true
     }
   ],
   "configServicePointer": { "projectId": "202", "projectEnvId": "308" }


### PR DESCRIPTION
It wasn't merging contexts in the bound client