### PR TITLE
Add pluggable EnvLookup interface for environment variable access (v0.3.0)

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -127,7 +127,7 @@ func NewClient(opts ...Option) (*Client, error) {
 
 	configStore := stores.BuildCompositeConfigStore(configStores...)
 
-	configResolver := internal.NewConfigResolver(configStore)
+	configResolver := internal.NewConfigResolver(configStore, options.CustomEnvLookup)
 
 	client = Client{
 		options:                &options,

--- a/pkg/internal/config_resolver_test.go
+++ b/pkg/internal/config_resolver_test.go
@@ -447,6 +447,7 @@ func TestConfigResolver_ResolveValue(t *testing.T) {
 				RuleEvaluator:         mockConfigEvaluator,
 				WeightedValueResolver: mockWeightedValueResolver,
 				Decrypter:             mockDecrypter,
+				EnvLookup:             &internal.RealEnvLookup{},
 			}
 
 			match, err := resolver.ResolveValue(testCase.configKey, mockContextGetter)

--- a/pkg/internal/options/options.go
+++ b/pkg/internal/options/options.go
@@ -11,6 +11,20 @@ import (
 	"github.com/prefab-cloud/prefab-cloud-go/pkg/internal/contexts"
 )
 
+// EnvLookup is an interface for looking up environment variables
+// This is defined in pkg/internal/interfaces.go but we reference it here
+// to avoid circular imports
+type EnvLookup interface {
+	LookupEnv(key string) (string, bool)
+}
+
+// RealEnvLookup implements EnvLookup using os.LookupEnv
+type RealEnvLookup struct{}
+
+func (RealEnvLookup) LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
 type OnInitializationFailure int
 
 const (
@@ -58,6 +72,7 @@ type Options struct {
 	TelemetrySyncInterval        time.Duration
 	TelemetryHost                string
 	InstanceHash                 string
+	CustomEnvLookup              EnvLookup
 }
 
 const timeoutDefault = 10.0
@@ -94,6 +109,7 @@ func GetDefaultOptions() Options {
 		TelemetryHost:                "https://telemetry.prefab.cloud",
 		CollectEvaluationSummaries:   true,
 		InstanceHash:                 uuid.New().String(),
+		CustomEnvLookup:              &RealEnvLookup{},
 	}
 }
 

--- a/pkg/internal/version.go
+++ b/pkg/internal/version.go
@@ -1,5 +1,5 @@
 package internal
 
-const Version = "0.2.3"
+const Version = "0.3.0"
 
 const ClientVersionHeader = "prefab-cloud-go-" + Version

--- a/pkg/option_helpers.go
+++ b/pkg/option_helpers.go
@@ -193,3 +193,23 @@ func WithAllTelemetryDisabled() Option {
 		return nil
 	}
 }
+
+// WithEnvLookup allows providing a custom environment variable lookup implementation.
+// This is useful for embedded scenarios where environment variable access needs to be controlled.
+//
+// Example:
+//
+//	type NoOpEnvLookup struct{}
+//	func (n *NoOpEnvLookup) LookupEnv(key string) (string, bool) {
+//		return "", false
+//	}
+//
+//	client, err := prefab.NewClient(
+//		prefab.WithEnvLookup(&NoOpEnvLookup{}),
+//	)
+func WithEnvLookup(envLookup options.EnvLookup) Option {
+	return func(o *options.Options) error {
+		o.CustomEnvLookup = envLookup
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds support for custom environment variable lookup implementations, bringing feature parity with the Java SDK's ConfigResolver pattern. This is useful for embedded scenarios where environment variable access needs to be controlled.

Backported from https://github.com/ReforgeHQ/sdk-go/pull/8

## Changes
- ✨ Add `EnvLookup` interface with `RealEnvLookup` default implementation
- 🔧 Update `handleProvided` to use `EnvLookup` instead of direct `os.LookupEnv`
- 🎯 Add `WithEnvLookup()` option for custom implementations
- 🔌 Wire `CustomEnvLookup` through SDK initialization
- ⚙️ Set `RealEnvLookup` as default in `GetDefaultOptions()`
- 📦 Bump version to **0.3.0**

## Example Usage
```go
type NoOpEnvLookup struct{}

func (n *NoOpEnvLookup) LookupEnv(key string) (string, bool) {
    return "", false
}

client, err := prefab.NewClient(
    prefab.WithEnvLookup(&NoOpEnvLookup{}),
)
```

## Test plan
- [x] All existing tests pass
- [x] Build succeeds
- [x] Fixed test to initialize EnvLookup field
- [x] Default behavior unchanged (uses `RealEnvLookup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)